### PR TITLE
arm: dts: qcom: Add uart3 to samsung-milletwifi

### DIFF
--- a/arch/arm/boot/dts/qcom/qcom-apq8026-samsung-milletwifi.dts
+++ b/arch/arm/boot/dts/qcom/qcom-apq8026-samsung-milletwifi.dts
@@ -26,6 +26,7 @@
 		display0 = &framebuffer0;
 		mmc0 = &sdhc_1; /* SDC1 eMMC slot */
 		mmc1 = &sdhc_2; /* SDC2 SD card slot */
+		serial0 = &blsp1_uart3;
 	};
 
 	chosen {
@@ -33,7 +34,7 @@
 		#size-cells = <1>;
 		ranges;
 
-		stdout-path = "display0";
+		stdout-path = "serial0:115200n8";
 
 		framebuffer0: framebuffer@3200000 {
 			compatible = "simple-framebuffer";
@@ -314,6 +315,10 @@
 		pinctrl-0 = <&tsp_int_rst_default_state>;
 		pinctrl-names = "default";
 	};
+};
+
+&blsp1_uart3 {
+	status = "okay";
 };
 
 &modem {


### PR DESCRIPTION
uart3 on samsung-milletwifi is exposed externally by a mux on the USB port.

Tested using a carkit serial cable with a resistor of 619k.

Signed-off-by: Bryant Mairs <bryant@mai.rs>