### PR TITLE
ARM: dts: qcom: msm8226-samsung-matisse-common: move accelerometer and touchscreen node into common dtsi

### DIFF
--- a/arch/arm/boot/dts/qcom/qcom-apq8026-samsung-matisse-wifi.dts
+++ b/arch/arm/boot/dts/qcom/qcom-apq8026-samsung-matisse-wifi.dts
@@ -12,66 +12,6 @@
 	model = "Samsung Galaxy Tab 4 10.1";
 	compatible = "samsung,matisse-wifi", "qcom,apq8026";
 	chassis-type = "tablet";
-
-	reg_tsp_3p3v: regulator-tsp-3p3v {
-		compatible = "regulator-fixed";
-		regulator-name = "tsp_3p3v";
-		regulator-min-microvolt = <3300000>;
-		regulator-max-microvolt = <3300000>;
-
-		gpio = <&tlmm 73 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-
-		pinctrl-names = "default";
-		pinctrl-0 = <&tsp_en1_default_state>;
-	};
-};
-
-&blsp1_i2c2 {
-	status = "okay";
-
-	accelerometer@1d {
-		compatible = "st,lis2hh12";
-		reg = <0x1d>;
-
-		interrupt-parent = <&tlmm>;
-		interrupts = <54 IRQ_TYPE_LEVEL_HIGH>;
-
-		pinctrl-names = "default";
-		pinctrl-0 = <&accel_int_default_state>;
-
-		st,drdy-int-pin = <1>;
-
-		vdd-supply = <&pm8226_l19>;
-		vddio-supply = <&pm8226_lvs1>;
-	};
-};
-
-&blsp1_i2c5 {
-	status = "okay";
-
-	touchscreen@4a {
-		compatible = "atmel,maxtouch";
-		reg = <0x4a>;
-
-		interrupt-parent = <&tlmm>;
-		interrupts = <17 IRQ_TYPE_LEVEL_LOW>;
-
-		linux,keycodes = <KEY_RESERVED>,
-				 <KEY_RESERVED>,
-				 <KEY_RESERVED>,
-				 <KEY_RESERVED>,
-				 <KEY_APPSELECT>,
-				 <KEY_BACK>;
-
-		pinctrl-names = "default";
-		pinctrl-0 = <&tsp_int_rst_default_state>;
-
-		reset-gpios = <&pm8226_gpios 6 GPIO_ACTIVE_LOW>;
-
-		vdd-supply = <&reg_tsp_1p8v>;
-		vdda-supply = <&reg_tsp_3p3v>;
-	};
 };
 
 &pm8226_l3 {
@@ -82,11 +22,10 @@
 	regulator-max-microvolt = <1800000>;
 };
 
-&tlmm {
-	tsp_en1_default_state: tsp-en1-default-state {
-		pins = "gpio73";
-		function = "gpio";
-		drive-strength = <2>;
-		bias-disable;
-	};
+&reg_tsp_3p3v {
+	gpio = <&tlmm 73 GPIO_ACTIVE_HIGH>;
+};
+
+&tsp_en1_default_state {
+	pins = "gpio73";
 };

--- a/arch/arm/boot/dts/qcom/qcom-msm8226-samsung-matisse-common.dtsi
+++ b/arch/arm/boot/dts/qcom/qcom-msm8226-samsung-matisse-common.dtsi
@@ -142,6 +142,19 @@
 		pinctrl-0 = <&tsp_en_default_state>;
 	};
 
+	reg_tsp_3p3v: regulator-tsp-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "tsp_3p3v";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+
+		/* gpio is filled in the dts*/
+		enable-active-high;
+
+		pinctrl-0 = <&tsp_en1_default_state>;
+		pinctrl-names = "default";
+	};
+
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -211,6 +224,25 @@
 	status = "okay";
 };
 
+&blsp1_i2c2 {
+	status = "okay";
+
+	accelerometer@1d {
+		compatible = "st,lis2hh12";
+		reg = <0x1d>;
+
+		interrupts-extended = <&tlmm 54 IRQ_TYPE_LEVEL_HIGH>;
+
+		pinctrl-0 = <&accel_int_default_state>;
+		pinctrl-names = "default";
+
+		st,drdy-int-pin = <1>;
+
+		vdd-supply = <&pm8226_l19>;
+		vddio-supply = <&pm8226_lvs1>;
+	};
+};
+
 &blsp1_i2c4 {
 	status = "okay";
 
@@ -223,6 +255,32 @@
 
 		pinctrl-names = "default";
 		pinctrl-0 = <&muic_int_default_state>;
+	};
+};
+
+&blsp1_i2c5 {
+	status = "okay";
+
+	touchscreen@4a {
+		compatible = "atmel,maxtouch";
+		reg = <0x4a>;
+
+		interrupts-extended = <&tlmm 17 IRQ_TYPE_LEVEL_LOW>;
+
+		linux,keycodes = <KEY_RESERVED>,
+				 <KEY_RESERVED>,
+				 <KEY_RESERVED>,
+				 <KEY_RESERVED>,
+				 <KEY_APPSELECT>,
+				 <KEY_BACK>;
+
+		pinctrl-0 = <&tsp_int_rst_default_state>;
+		pinctrl-names = "default";
+
+		reset-gpios = <&pm8226_gpios 6 GPIO_ACTIVE_LOW>;
+
+		vdd-supply = <&reg_tsp_1p8v>;
+		vdda-supply = <&reg_tsp_3p3v>;
 	};
 };
 
@@ -469,6 +527,13 @@
 
 	tsp_en_default_state: tsp-en-default-state {
 		pins = "gpio31";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	tsp_en1_default_state: tsp-en1-default-state {
+		/* gpio is filled in the dts*/
 		function = "gpio";
 		drive-strength = <2>;
 		bias-disable;

--- a/arch/arm/boot/dts/qcom/qcom-msm8926-samsung-matisselte.dts
+++ b/arch/arm/boot/dts/qcom/qcom-msm8926-samsung-matisselte.dts
@@ -13,30 +13,8 @@
 	model = "Samsung Galaxy Tab 4 10.1 LTE";
 	compatible = "samsung,matisselte", "qcom,msm8926", "qcom,msm8226";
 	chassis-type = "tablet";
-
-	reg_tsp_3p3v: regulator-tsp-3p3v {
-		compatible = "regulator-fixed";
-		regulator-name = "tsp_3p3v";
-		regulator-min-microvolt = <3300000>;
-		regulator-max-microvolt = <3300000>;
-
-		gpio = <&tlmm 32 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-
-		pinctrl-names = "default";
-		pinctrl-0 = <&tsp_en1_default_state>;
-	};
 };
 
 &modem {
 	mss-supply = <&pm8226_s5>;
-};
-
-&tlmm {
-	tsp_en1_default_state: tsp-en1-default-state {
-		pins = "gpio32";
-		function = "gpio";
-		drive-strength = <2>;
-		bias-disable;
-	};
 };


### PR DESCRIPTION


I checked the downstream.
Accelerometer and touchscreen node in the downstream device tree of matisselte matisse-wifi are quite similar.Therefore they should be in the common dtsi.