### PR TITLE
dts: arm: qcom: motorola-titan: Add initial device tree

### DIFF
--- a/Documentation/devicetree/bindings/arm/qcom.yaml
+++ b/Documentation/devicetree/bindings/arm/qcom.yaml
@@ -160,6 +160,7 @@ properties:
               - microsoft,makepeace
               - microsoft,moneypenny
               - motorola,falcon
+              - motorola,titan
               - samsung,ms013g
               - samsung,s3ve3g
           - const: qcom,msm8226

--- a/arch/arm/boot/dts/qcom/Makefile
+++ b/arch/arm/boot/dts/qcom/Makefile
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0
 dtb-$(CONFIG_ARCH_QCOM) += \
 	msm8226-motorola-falcon.dtb \
+	msm8226-motorola-titan.dtb \
 	qcom-apq8016-sbc.dtb \
 	qcom-apq8026-asus-sparrow.dtb \
 	qcom-apq8026-huawei-sturgeon.dtb \

--- a/arch/arm/boot/dts/qcom/msm8226-motorola-titan.dts
+++ b/arch/arm/boot/dts/qcom/msm8226-motorola-titan.dts
@@ -1,0 +1,351 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2026, David Wales <daviewales@disroot.org>
+ */
+
+/dts-v1/;
+
+#include "qcom-msm8226.dtsi"
+#include "pm8226.dtsi"
+
+/delete-node/ &smem_region;
+
+/ {
+	model = "Motorola Moto G2 (2014)";
+	compatible = "motorola,titan", "qcom,msm8226";
+	chassis-type = "handset";
+
+	aliases {
+		mmc0 = &sdhc_1; /* eMMC */
+	};
+
+	chosen {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		framebuffer@3200000 {
+			compatible = "simple-framebuffer";
+			reg = <0x03200000 0x800000>;
+			width = <720>;
+			height = <1280>;
+			stride = <(720 * 3)>;
+			format = "r8g8b8";
+			vsp-supply = <&reg_lcd_pos>;
+			vsn-supply = <&reg_lcd_neg>;
+			vddio-supply = <&vddio_disp_vreg>;
+
+			clocks = <&mmcc MDSS_AHB_CLK>,
+				 <&mmcc MDSS_AXI_CLK>,
+				 <&mmcc MDSS_BYTE0_CLK>,
+				 <&mmcc MDSS_ESC0_CLK>,
+				 <&mmcc MDSS_MDP_CLK>,
+				 <&mmcc MMSS_MISC_AHB_CLK>,
+				 <&mmcc MDSS_PCLK0_CLK>,
+				 <&mmcc MDSS_VSYNC_CLK>;
+			power-domains = <&mmcc MDSS_GDSC>;
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		event-hall-sensor {
+			label = "Hall Effect Sensor";
+			gpios = <&tlmm 109 GPIO_ACTIVE_LOW>;
+			linux,input-type = <EV_SW>;
+			linux,code = <SW_LID>;
+			linux,can-disable;
+		};
+
+		key-volume-down {
+			label = "Volume Down";
+			gpios = <&tlmm 107 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_VOLUMEDOWN>;
+			debounce-interval = <15>;
+		};
+
+		key-volume-up {
+			label = "Volume Up";
+			gpios = <&tlmm 106 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_VOLUMEUP>;
+			debounce-interval = <15>;
+		};
+	};
+
+	vddio_disp_vreg: regulator-vddio-disp {
+		compatible = "regulator-fixed";
+		regulator-name = "vddio_disp";
+
+		gpio = <&tlmm 10 GPIO_ACTIVE_HIGH>;
+		startup-delay-us = <300>;
+		enable-active-high;
+		regulator-boot-on;
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		framebuffer@3200000 {
+			reg = <0x03200000 0xfa0000>;
+			no-map;
+		};
+
+		dhob@f500000 {
+			reg = <0x0f500000 0x40000>;
+			no-map;
+		};
+
+		shob@f540000 {
+			reg = <0x0f540000 0x2000>;
+			no-map;
+		};
+
+		smem_region: smem@fa00000 {
+			reg = <0x0fa00000 0x100000>;
+			no-map;
+		};
+
+		reserved@fb00000 {
+			reg = <0x0fb00000 0x400000>;
+			no-map;
+		};
+	};
+};
+
+&blsp1_i2c4 {
+	status = "okay";
+
+	regulator@3e {
+		compatible = "ti,tps65132";
+		reg = <0x3e>;
+
+		pinctrl-0 = <&reg_lcd_default>;
+		pinctrl-names = "default";
+
+		reg_lcd_pos: outp {
+			regulator-name = "outp";
+			regulator-min-microvolt = <5400000>;
+			regulator-max-microvolt = <5600000>;
+			regulator-active-discharge = <1>;
+			regulator-boot-on;
+			enable-gpios = <&tlmm 12 GPIO_ACTIVE_HIGH>;
+		};
+
+		reg_lcd_neg: outn {
+			regulator-name = "outn";
+			regulator-min-microvolt = <5400000>;
+			regulator-max-microvolt = <5600000>;
+			regulator-active-discharge = <1>;
+			regulator-boot-on;
+			enable-gpios = <&tlmm 13 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&pm8226_vib {
+	status = "okay";
+};
+
+&rpm_requests {
+	regulators {
+		compatible = "qcom,rpm-pm8226-regulators";
+
+		pm8226_s3: s3 {
+			regulator-min-microvolt = <1200000>;
+			regulator-max-microvolt = <1300000>;
+		};
+
+		pm8226_s4: s4 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <2200000>;
+		};
+
+		pm8226_s5: s5 {
+			regulator-min-microvolt = <1150000>;
+			regulator-max-microvolt = <1150000>;
+		};
+
+		pm8226_l1: l1 {
+			regulator-min-microvolt = <1225000>;
+			regulator-max-microvolt = <1225000>;
+		};
+
+		pm8226_l2: l2 {
+			regulator-min-microvolt = <1200000>;
+			regulator-max-microvolt = <1200000>;
+		};
+
+		pm8226_l3: l3 {
+			regulator-min-microvolt = <750000>;
+			regulator-max-microvolt = <1337500>;
+		};
+
+		pm8226_l4: l4 {
+			regulator-min-microvolt = <1200000>;
+			regulator-max-microvolt = <1200000>;
+		};
+
+		pm8226_l5: l5 {
+			regulator-min-microvolt = <1200000>;
+			regulator-max-microvolt = <1200000>;
+		};
+
+		pm8226_l6: l6 {
+			/* Hall effect sensor */
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+			regulator-always-on;
+		};
+
+		pm8226_l7: l7 {
+			regulator-min-microvolt = <1850000>;
+			regulator-max-microvolt = <1850000>;
+		};
+
+		pm8226_l8: l8 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+		};
+
+		pm8226_l9: l9 {
+			regulator-min-microvolt = <2050000>;
+			regulator-max-microvolt = <2050000>;
+		};
+
+		pm8226_l10: l10 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+		};
+
+		pm8226_l12: l12 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+		};
+
+		pm8226_l14: l14 {
+			regulator-min-microvolt = <2750000>;
+			regulator-max-microvolt = <2750000>;
+		};
+
+		pm8226_l15: l15 {
+			regulator-min-microvolt = <2800000>;
+			regulator-max-microvolt = <2800000>;
+		};
+
+		pm8226_l16: l16 {
+			regulator-min-microvolt = <3000000>;
+			regulator-max-microvolt = <3350000>;
+		};
+
+		pm8226_l17: l17 {
+			regulator-min-microvolt = <2950000>;
+			regulator-max-microvolt = <2950000>;
+		};
+
+		pm8226_l18: l18 {
+			regulator-min-microvolt = <2950000>;
+			regulator-max-microvolt = <2950000>;
+		};
+
+		pm8226_l19: l19 {
+			regulator-min-microvolt = <2850000>;
+			regulator-max-microvolt = <2850000>;
+		};
+
+		pm8226_l20: l20 {
+			regulator-min-microvolt = <3075000>;
+			regulator-max-microvolt = <3075000>;
+		};
+
+		pm8226_l21: l21 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <2950000>;
+			regulator-allow-set-load;
+		};
+
+		pm8226_l22: l22 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <2950000>;
+		};
+
+		pm8226_l23: l23 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <2950000>;
+		};
+
+		pm8226_l24: l24 {
+			regulator-min-microvolt = <1300000>;
+			regulator-max-microvolt = <1350000>;
+		};
+
+		pm8226_l25: l25 {
+			regulator-min-microvolt = <1775000>;
+			regulator-max-microvolt = <2125000>;
+		};
+
+		pm8226_l26: l26 {
+			regulator-min-microvolt = <1225000>;
+			regulator-max-microvolt = <1225000>;
+		};
+
+		pm8226_l27: l27 {
+			regulator-min-microvolt = <2050000>;
+			regulator-max-microvolt = <2050000>;
+		};
+
+		pm8226_l28: l28 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <3400000>;
+			regulator-boot-on;
+		};
+
+		pm8226_lvs1: lvs1 {
+			/* Pull-up for I2C lines */
+			regulator-always-on;
+		};
+	};
+};
+
+&sdhc_1 {
+	vmmc-supply = <&pm8226_l17>;
+	vqmmc-supply = <&pm8226_l6>;
+	bus-width = <8>;
+	non-removable;
+
+	status = "okay";
+};
+
+&smbb {
+	qcom,fast-charge-safe-current = <2000000>;
+	qcom,fast-charge-current-limit = <1900000>;
+	qcom,fast-charge-safe-voltage = <4400000>;
+	qcom,minimum-input-voltage = <4300000>;
+
+	status = "okay";
+};
+
+&usb {
+	extcon = <&smbb>;
+	dr_mode = "peripheral";
+
+	status = "okay";
+};
+
+&usb_hs_phy {
+	extcon = <&smbb>;
+	v1p8-supply = <&pm8226_l10>;
+	v3p3-supply = <&pm8226_l20>;
+};
+
+&tlmm {
+	reg_lcd_default: reg-lcd-default-state {
+		pins = "gpio12", "gpio13";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+		output-high;
+	};
+};


### PR DESCRIPTION
Works with PostmarketOS `device-qcom-msm8226` generic device.
Requires custom `lk2nd` build, due to conflict with other board ID (quirky device).

I've tested the following work:

- Framebuffer
- SSH over USB
- Events from power, volume up, volume down (`evtest`)
- Vibrator motor (`fftest`)
- Flashing to eMMC (internal storage), read, write.

So far as I can tell, the external storage (SD card) cd-gpio detection is correct, but using the SD card is not yet working, so I've left that disabled.

`dmesg` output included below for reference.
<details>

``` dmesg
[    0.000000] Booting Linux on physical CPU 0x0
[    0.000000] Linux version 6.15.2 (pmos@dwales-thinkpad) (Alpine clang version 22.1.0, LLD 22.1.0) #39 SMP PREEMPT Fri Mar  6 10:30:37 UTC 2026
[    0.000000] CPU: ARMv7 Processor [410fc073] revision 3 (ARMv7), cr=10c5387d
[    0.000000] CPU: div instructions available: patching division code
[    0.000000] CPU: PIPT / VIPT nonaliasing data cache, VIPT aliasing instruction cache
[    0.000000] OF: fdt: Machine model: Motorola Moto G2 (2014)
[    0.000000] Malformed early option 'earlycon'
[    0.000000] Memory policy: Data cache writealloc
[    0.000000] cma: Reserved 256 MiB at 0x30000000
[    0.000000] Zone ranges:
[    0.000000]   Normal   [mem 0x0000000000000000-0x000000002fffffff]
[    0.000000]   HighMem  [mem 0x0000000030000000-0x000000003fffffff]
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000000000000-0x00000000031fffff]
[    0.000000]   node   0: [mem 0x0000000003200000-0x000000000419ffff]
[    0.000000]   node   0: [mem 0x00000000041a0000-0x000000000d1fffff]
[    0.000000]   node   0: [mem 0x000000000d200000-0x000000000f541fff]
[    0.000000]   node   0: [mem 0x000000000f542000-0x000000000f9fffff]
[    0.000000]   node   0: [mem 0x000000000fa00000-0x000000000fefffff]
[    0.000000]   node   0: [mem 0x000000000ff00000-0x000000003fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x000000003fffffff]
[    0.000000] OF: reserved mem: 0x0d200000..0x0dbfffff (10240 KiB) nomap non-reusable wcnss@d200000
[    0.000000] OF: reserved mem: 0x0dc00000..0x0f4fffff (25600 KiB) nomap non-reusable adsp@dc00000
[    0.000000] OF: reserved mem: 0x03200000..0x0419ffff (16000 KiB) nomap non-reusable framebuffer@3200000
[    0.000000] OF: reserved mem: 0x0f500000..0x0f53ffff (256 KiB) nomap non-reusable dhob@f500000
[    0.000000] OF: reserved mem: 0x0f540000..0x0f541fff (8 KiB) nomap non-reusable shob@f540000
[    0.000000] OF: reserved mem: 0x0fa00000..0x0fafffff (1024 KiB) nomap non-reusable smem@fa00000
[    0.000000] OF: reserved mem: 0x0fb00000..0x0fefffff (4096 KiB) nomap non-reusable reserved@fb00000
[    0.000000] percpu: Embedded 13 pages/cpu s21068 r8192 d23988 u53248
[    0.000000] pcpu-alloc: s21068 r8192 d23988 u53248 alloc=13*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1 [0] 2 [0] 3
[    0.000000] Kernel command line: quiet earlycon console=ttyMSM0,115200 msm.allow_vram_carveout=1 cma=256m msm.vram=192m pmos_boot_uuid=6dd0ac82-ccdd-4c53-8f43-d56c2c7aee4f pmos_root_uuid=041edd21-8a39-4d84-b4a3-582f8ee0a793 pmos_rootfsopts=defaults
[    0.000000] Unknown kernel command line parameters "pmos_boot_uuid=6dd0ac82-ccdd-4c53-8f43-d56c2c7aee4f pmos_root_uuid=041edd21-8a39-4d84-b4a3-582f8ee0a793 pmos_rootfsopts=defaults", will be passed to user space.
[    0.000000] printk: log buffer data + meta data: 131072 + 409600 = 540672 bytes
[    0.000000] Dentry cache hash table entries: 131072 (order: 7, 524288 bytes, linear)
[    0.000000] Inode-cache hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 262144
[    0.000000] mem auto-init: stack:all(zero), heap alloc:off, heap free:off
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=4, Nodes=1
[    0.000000] rcu: Preemptible hierarchical RCU implementation.
[    0.000000]  Trampoline variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] RCU Tasks: Setting shift to 2 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=4.
[    0.000000] NR_IRQS: 16, nr_irqs: 16, preallocated irqs: 16
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] arch_timer: cp15 and mmio timer(s) running at 19.20MHz (virt/virt).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x46d987e47, max_idle_ns: 440795202767 ns
[    0.000002] sched_clock: 56 bits at 19MHz, resolution 52ns, wraps every 4398046511078ns
[    0.000017] Switching to timer-based delay loop, resolution 52ns
[    0.000268] Console: colour dummy device 80x30
[    0.000315] Calibrating delay loop (skipped), value calculated using timer frequency.. 38.40 BogoMIPS (lpj=192000)
[    0.000333] CPU: Testing write buffer coherency: ok
[    0.000375] pid_max: default: 32768 minimum: 301
[    0.000575] Mount-cache hash table entries: 2048 (order: 1, 8192 bytes, linear)
[    0.000596] Mountpoint-cache hash table entries: 2048 (order: 1, 8192 bytes, linear)
[    0.001546] /cpus/cpu@0 missing clock-frequency property
[    0.001576] /cpus/cpu@1 missing clock-frequency property
[    0.001597] /cpus/cpu@2 missing clock-frequency property
[    0.001619] /cpus/cpu@3 missing clock-frequency property
[    0.001632] CPU0: thread -1, cpu 0, socket 0, mpidr 80000000
[    0.001690] qcom_scm: convention: smc legacy
[    0.050347] Setting up static identity map for 0x100000 - 0x100060
[    0.060162] rcu: Hierarchical SRCU implementation.
[    0.060169] rcu:     Max phase no-delay instances is 1000.
[    0.070287] Timer migration: 1 hierarchy levels; 8 children per group; 1 crossnode level
[    0.090203] smp: Bringing up secondary CPUs ...
[    0.120743] CPU1: thread -1, cpu 1, socket 0, mpidr 80000001
[    0.150612] CPU2: thread -1, cpu 2, socket 0, mpidr 80000002
[    0.170773] CPU3: thread -1, cpu 3, socket 0, mpidr 80000003
[    0.170988] smp: Brought up 1 node, 4 CPUs
[    0.171000] SMP: Total of 4 processors activated (153.60 BogoMIPS).
[    0.171010] CPU: All CPU(s) started in SVC mode.
[    0.171839] Memory: 691896K/1048576K available (10240K kernel code, 964K rwdata, 2916K rodata, 1024K init, 271K bss, 92324K reserved, 262144K cma-reserved, 0K highmem)
[    0.172491] devtmpfs: initialized
[    0.183397] VFP support v0.3: implementor 41 architecture 2 part 30 variant 7 rev 3
[    0.183854] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.183877] posixtimers hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.183903] futex hash table entries: 1024 (order: 4, 65536 bytes, linear)
[    0.187355] pinctrl core: initialized pinctrl subsystem
[    0.189644] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.191016] DMA: preallocated 256 KiB pool for atomic coherent allocations
[    0.192409] thermal_sys: Registered thermal governor 'step_wise'
[    0.192475] cpuidle: using governor menu
[    0.192672] NET: Registered PF_QIPCRTR protocol family
[    0.192877] hw-breakpoint: Debug register access (0xee001e17) caused undefined instruction on CPU 0
[    0.192890] hw-breakpoint: CPU 0 failed to disable vector catch
[    0.192933] hw-breakpoint: Debug register access (0xee001e17) caused undefined instruction on CPU 1
[    0.192988] hw-breakpoint: Debug register access (0xee001e17) caused undefined instruction on CPU 2
[    0.193035] hw-breakpoint: Debug register access (0xee001e17) caused undefined instruction on CPU 3
[    0.200711] /soc/usb@f9a55000: Fixed dependency cycle(s) with /soc/usb@f9a55000/ulpi/phy
[    0.200767] /soc/usb@f9a55000/ulpi/phy: Fixed dependency cycle(s) with /soc/usb@f9a55000
[    0.206569] /soc/usb@f9a55000: Fixed dependency cycle(s) with /soc/usb@f9a55000/ulpi/phy
[    0.206623] /soc/usb@f9a55000/ulpi/phy: Fixed dependency cycle(s) with /soc/usb@f9a55000
[    0.217090] kprobes: kprobe jump-optimization is enabled. All kprobes are optimized if possible.
[    0.219565] iommu: Default domain type: Translated
[    0.219576] iommu: DMA domain TLB invalidation policy: strict mode
[    0.220739] SCSI subsystem initialized
[    0.221001] libata version 3.00 loaded.
[    0.221347] usbcore: registered new interface driver usbfs
[    0.221407] usbcore: registered new interface driver hub
[    0.221461] usbcore: registered new device driver usb
[    0.222600] Advanced Linux Sound Architecture Driver Initialized.
[    0.223388] Bluetooth: Core ver 2.22
[    0.223434] NET: Registered PF_BLUETOOTH protocol family
[    0.223441] Bluetooth: HCI device and connection manager initialized
[    0.223454] Bluetooth: HCI socket layer initialized
[    0.223464] Bluetooth: L2CAP socket layer initialized
[    0.223483] Bluetooth: SCO socket layer initialized
[    0.223791] nfc: nfc_init: NFC Core ver 0.1
[    0.223885] NET: Registered PF_NFC protocol family
[    0.224375] clocksource: Switched to clocksource arch_sys_counter
[    0.238495] NET: Registered PF_INET protocol family
[    0.238759] IP idents hash table entries: 16384 (order: 5, 131072 bytes, linear)
[    0.241318] tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.241349] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.241365] TCP established hash table entries: 8192 (order: 3, 32768 bytes, linear)
[    0.241468] TCP bind hash table entries: 8192 (order: 5, 131072 bytes, linear)
[    0.241741] TCP: Hash tables configured (established 8192 bind 8192)
[    0.241868] UDP hash table entries: 512 (order: 2, 28672 bytes, linear)
[    0.241938] UDP-Lite hash table entries: 512 (order: 2, 28672 bytes, linear)
[    0.242159] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.243418] Initialise system trusted keyrings
[    0.243992] Trying to unpack rootfs image as initramfs...
[    0.244504] workingset: timestamp_bits=30 max_order=18 bucket_order=0
[    0.244954] jffs2: version 2.2. (NAND) © 2001-2006 Red Hat, Inc.
[    0.245071] fuse: init (API version 7.43)
[    0.494276] Key type asymmetric registered
[    0.494297] Asymmetric key parser 'x509' registered
[    0.494474] bounce: pool size: 64 pages
[    0.494567] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 248)
[    0.494579] io scheduler mq-deadline registered
[    0.494586] io scheduler kyber registered
[    0.494619] io scheduler bfq registered
[    0.508028] msm_serial: driver initialized
[    0.521016] brd: module loaded
[    0.529437] loop: module loaded
[    0.557819] SCSI Media Changer driver v0.25
[    0.558916] spmi_pmic_arb fc4cf000.spmi: PMIC arbiter version v1 (0x20000002)
[    0.574492] usbcore: registered new interface driver cdc_acm
[    0.574510] cdc_acm: USB Abstract Control Model driver for USB modems and ISDN adapters
[    0.576358] UDC core: g_ether: couldn't find an available UDC
[    0.577341] input: pm8xxx_vib_ffmemless as /devices/platform/soc/fc4cf000.spmi/spmi-0/0-01/fc4cf000.spmi:pm8226@1:vibrator@c000/input/input0
[    0.579892] rtc-pm8xxx fc4cf000.spmi:pm8226@0:rtc@6000: registered as rtc0
[    0.579971] rtc-pm8xxx fc4cf000.spmi:pm8226@0:rtc@6000: setting system clock to 1970-01-01T15:54:54 UTC (57294)
[    0.580097] i2c_dev: i2c /dev entries driver
[    0.580393] i2c_qup f9926000.i2c: using default clock-frequency 100000
[    0.580414] i2c_qup f9926000.i2c:
                tx channel not available
[    0.583705] input: pm8941_pwrkey as /devices/platform/soc/fc4cf000.spmi/spmi-0/0-00/fc4cf000.spmi:pm8226@0:pon@800/fc4cf000.spmi:pm8226@0:pon@800:pwrkey/input/input1
[    0.585153] qcom-smbb fc4cf000.spmi:pm8226@0:charger@1000: Initializing SMBB rev 1
[    0.594747] device-mapper: ioctl: 4.49.0-ioctl (2025-01-17) initialised: dm-devel@lists.linux.dev
[    0.596065] sdhci: Secure Digital Host Controller Interface driver
[    0.596073] sdhci: Copyright(c) Pierre Ossman
[    0.596078] sdhci-pltfm: SDHCI platform and OF driver helper
[    0.598958] usbcore: registered new interface driver usbhid
[    0.598972] usbhid: USB HID core driver
[    0.610329] hw perfevents: enabled with armv7_cortex_a7 PMU driver, 5 (8000000f) counters available
[    0.612857] NET: Registered PF_PACKET protocol family
[    0.613111] Bluetooth: RFCOMM TTY layer initialized
[    0.613130] Bluetooth: RFCOMM socket layer initialized
[    0.613155] Bluetooth: RFCOMM ver 1.11
[    0.613172] Bluetooth: BNEP (Ethernet Emulation) ver 1.3
[    0.613179] Bluetooth: BNEP filters: protocol multicast
[    0.613190] Bluetooth: BNEP socket layer initialized
[    0.613197] Bluetooth: HIDP (Human Interface Emulation) ver 1.2
[    0.613207] Bluetooth: HIDP socket layer initialized
[    0.613300] Key type dns_resolver registered
[    0.613425] Registering SWP/SWPB emulation handler
[    0.626856] Loading compiled-in X.509 certificates
[    0.804464] Freeing initrd memory: 9132K
[    0.821478] cpufreq: cpufreq_online: CPU0: Running at unlisted initial frequency: 800000 kHz, changing to: 787200 kHz
[    0.825024] msm_hsusb f9a55000.usb: Failed to create device link (0x180) with supplier remoteproc:smd-edge:rpm-requests:clock-controller for /soc/usb@f9a55000/ulpi/phy
[    0.826073] msm_hsusb f9a55000.usb: Failed to create device link (0x180) with supplier remoteproc for /soc/usb@f9a55000/ulpi/phy
[    0.849178] msm_hsusb f9a55000.usb: Failed to create device link (0x180) with supplier remoteproc:smd-edge:rpm-requests:clock-controller for /soc/usb@f9a55000/ulpi/phy
[    0.852325] s3: Bringing 0uV into 1200000-1200000uV
[    0.852776] s4: Bringing 0uV into 1800000-1800000uV
[    0.853198] s5: Bringing 0uV into 1150000-1150000uV
[    0.853607] l1: Bringing 0uV into 1225000-1225000uV
[    0.854601] l2: Bringing 0uV into 1200000-1200000uV
[    0.855019] l3: Bringing 0uV into 750000-750000uV
[    0.855399] l4: Bringing 0uV into 1200000-1200000uV
[    0.855775] l5: Bringing 0uV into 1200000-1200000uV
[    0.856170] l6: Bringing 0uV into 1800000-1800000uV
[    0.856567] l7: Bringing 0uV into 1850000-1850000uV
[    0.856970] l8: Bringing 0uV into 1800000-1800000uV
[    0.857357] l9: Bringing 0uV into 2050000-2050000uV
[    0.857769] l10: Bringing 0uV into 1800000-1800000uV
[    0.858182] l12: Bringing 0uV into 1800000-1800000uV
[    0.858589] l14: Bringing 0uV into 2750000-2750000uV
[    0.859000] l15: Bringing 0uV into 2800000-2800000uV
[    0.859413] l16: Bringing 0uV into 3000000-3000000uV
[    0.859832] l17: Bringing 0uV into 2950000-2950000uV
[    0.860223] l18: Bringing 0uV into 2950000-2950000uV
[    0.860649] l19: Bringing 0uV into 2850000-2850000uV
[    0.861065] l20: Bringing 0uV into 3075000-3075000uV
[    0.861496] l21: Bringing 0uV into 1800000-1800000uV
[    0.861921] l22: Bringing 0uV into 1800000-1800000uV
[    0.862361] l23: Bringing 0uV into 1800000-1800000uV
[    0.862791] l24: Bringing 0uV into 1300000-1300000uV
[    0.863222] l25: Bringing 0uV into 1775000-1775000uV
[    0.863665] l26: Bringing 0uV into 1225000-1225000uV
[    0.864077] l27: Bringing 0uV into 2050000-2050000uV
[    0.864710] l28: Bringing 0uV into 1800000-1800000uV
[    0.865811] ocmem fdd00000.sram: 2 ports, 1 regions, 2 macros, not interleaved
[    0.869430] [drm] Initialized simpledrm 1.0.0 for 3200000.framebuffer on minor 0
[    0.877892] Console: switching to colour frame buffer device 90x80
[    0.909770] simple-framebuffer 3200000.framebuffer: [drm] fb0: simpledrmdrmfb frame buffer device
[    0.922840] mmc0: SDHCI controller on f9824900.mmc [f9824900.mmc] using ADMA
[    0.927205] g_ether gadget.0: HOST MAC b2:1b:e2:67:3a:8b
[    0.927222] g_ether gadget.0: MAC 36:e2:9c:17:a1:4a
[    0.927492] g_ether gadget.0: Ethernet Gadget, version: Memorial Day 2008
[    0.927505] g_ether gadget.0: g_ether ready
[    0.928103] l20: voltage operation not allowed
[    0.929600] input: gpio-keys as /devices/platform/gpio-keys/input/input2
[    0.930578] clk: Disabling unused clocks
[    0.930907] PM: genpd: Disabling unused power domains
[    0.931918] ALSA device list:
[    0.931929]   No soundcards found.
[    0.931980] Warning: unable to open an initial console.
[    0.933496] Freeing unused kernel image (initmem) memory: 1024K
[    0.933783] Run /init as init process
[    0.933789]   with arguments:
[    0.933796]     /init
[    0.933801]   with environment:
[    0.933807]     HOME=/
[    0.933812]     TERM=linux
[    0.933817]     pmos_boot_uuid=6dd0ac82-ccdd-4c53-8f43-d56c2c7aee4f
[    0.933824]     pmos_root_uuid=041edd21-8a39-4d84-b4a3-582f8ee0a793
[    0.933830]     pmos_rootfsopts=defaults
[    0.990088] mmc0: new HS200 MMC card at address 0001
[    1.001106] mmcblk0: mmc0:0001 SEM08G 7.28 GiB
[    1.005765]  mmcblk0: p1 p2 p3 p4 p5 p6 p7 p8 p9 p10 p11 p12 p13 p14 p15 p16 p17 p18 p19 p20 p21 p22 p23 p24 p25 p26 p27 p28 p29 p30 p31 p32 p33 p34 p35 p36 p37 p38
[    1.014986] mmcblk0boot0: mmc0:0001 SEM08G 2.00 MiB
[    1.017004] mmcblk0boot1: mmc0:0001 SEM08G 2.00 MiB
[    1.019089] mmcblk0rpmb: mmc0:0001 SEM08G 2.00 MiB, chardev (243:0)
[    1.030372] syslogd started: BusyBox v1.37.0
[    1.035875] [pmOS-rd]:   ❬❬ PMOS STAGE 1 ❭❭
[    1.035907] [pmOS-rd]: initramfs version: 3.9.3-r0
[    1.035927] [pmOS-rd]:   ❬❬ PMOS STAGE 2 ❭❭
[    1.079287] [pmOS-rd]: Starting systemd-udevd version 259.2
[    3.315697] [pmOS-rd]:   Setting up USB gadget through configfs
[    3.347166] UDC core: g1: couldn't find an available UDC or it's busy
[    3.347544] [pmOS-rd]: ash: write error: Resource busy
[    3.347571] [pmOS-rd]:   Couldn't write new UDC
[    3.401110] [pmOS-rd]: Trying to start server with parameters: Server IP addr: 172.16.42.1:67, client IP addr: 172.16.42.2, interface: usb0
[    3.413402] [pmOS-rd]: Setting framebuffer mode to: U:720x1280p-0
[    3.513087] [pmOS-rd]: tfb_acquire_fb() failed with error code: 7
[    4.521563] [pmOS-rd]: Trying to mount subpartitions for 10 seconds...
[    6.451261] [pmOS-rd]: Mount subpartitions of /dev/mmcblk0p38
[    6.459194] loop0: detected capacity change from 0 to 11548416
[    6.460225]  loop0: p1 p2
[    8.364661] [pmOS-rd]: Not resizing root partition (/dev/loop0p2): no free space left
[    8.376056] [pmOS-rd]: Auto-repair and check 'ext' filesystem (/dev/loop0p2)
[    8.387718] [pmOS-rd]: pmOS_root: clean, 11127/317168 files, 161574/1381088 blocks
[    8.446953] [pmOS-rd]: tfb_acquire_fb() failed with error code: 7
[    8.472039] [pmOS-rd]: Resize 'ext4' root filesystem (/dev/loop0p2)
[    8.485130] [pmOS-rd]: resize2fs 1.47.3 (8-Jul-2025)
[    8.487204] [pmOS-rd]: The filesystem is already 1381088 (4k) blocks long.  Nothing to do!
[    8.505326] [pmOS-rd]: Mount root partition (/dev/loop0p2) to /sysroot (read-write) with options defaults
[    8.573266] EXT4-fs (loop0p2): mounted filesystem 041edd21-8a39-4d84-b4a3-582f8ee0a793 r/w with ordered data mode. Quota mode: disabled.
[    8.603646] [pmOS-rd]: Switching root
[    8.603830] [pmOS-rd]: [pmOS-rd] Disabling console output again (use 'pmos.debug-shell' to keep it enabled)
[    8.662215] syslogd exiting
[    8.810488] systemd[1]: System time advanced to timestamp on /var/lib/systemd/timesync/clock: Wed 2026-03-04 17:20:00 AEDT
[    8.838929] systemd[1]: Failed to find module 'autofs4'
[    8.863378] systemd[1]: systemd 259.2 running in system mode (+PAM +AUDIT -SELINUX +APPARMOR +IMA +IPE +SMACK +SECCOMP +GCRYPT +GNUTLS +OPENSSL +ACL +BLKID +CURL +ELFUTILS +FIDO2 +IDN2 -IDN +KMOD +LIBCRYPTSETUP +LIBCRYPTSETUP_PLUGINS +LIBFDISK +PCRE2 -PWQUALITY +P11KIT +QRENCODE -TPM2 +BZIP2 +LZ4 +XZ +ZLIB +ZSTD +BPF_FRAMEWORK +BTF +XKBCOMMON -UTMP -SYSVINIT -LIBARCHIVE)
[    8.863429] systemd[1]: Detected architecture arm.
[    8.869302] systemd[1]: Hostname set to <qcom-msm8226>.
[    8.969026] systemd[1]: bpf-restrict-fs: BPF LSM hook not enabled in the kernel, BPF LSM not supported.
[   10.214525] systemd[1]: Queued start job for default target Graphical Interface.
[   14.362023] systemd[1]: Created slice Slice /system/getty.
[   14.369042] systemd[1]: Created slice Slice /system/modprobe.
[   14.371725] systemd[1]: Created slice User and Session Slice.
[   14.372834] systemd[1]: Started Dispatch Password Requests to Console Directory Watch.
[   14.373900] systemd[1]: Started Forward Password Requests to Wall Directory Watch.
[   14.374562] systemd[1]: Arbitrary Executable File Formats File System Automount Point skipped, unmet condition check ConditionPathExists=/proc/sys/fs/binfmt_misc
[   14.375123] systemd[1]: Expecting device /dev/disk/by-uuid/6dd0ac82-ccdd-4c53-8f43-d56c2c7aee4f...
[   14.375588] systemd[1]: Reached target Local Encrypted Volumes.
[   14.376397] systemd[1]: Reached target Image Downloads.
[   14.376908] systemd[1]: Reached target Local Integrity Protected Volumes.
[   14.378233] systemd[1]: Reached target Path Units.
[   14.378820] systemd[1]: Reached target Remote Encrypted Volumes.
[   14.379621] systemd[1]: Reached target Remote File Systems.
[   14.380261] systemd[1]: Reached target Remote Integrity Protected Volumes.
[   14.380830] systemd[1]: Reached target Remote Verity Protected Volumes.
[   14.381405] systemd[1]: Reached target Slice Units.
[   14.383090] systemd[1]: Reached target Local Verity Protected Volumes.
[   14.439924] systemd[1]: Listening on Query the User Interactively for a Password.
[   14.495866] systemd[1]: Listening on Process Core Dump Socket.
[   14.532811] systemd[1]: Listening on Credential Encryption/Decryption.
[   14.567566] systemd[1]: Listening on Factory Reset Management.
[   14.568892] systemd[1]: Listening on Journal Socket (/dev/log).
[   14.570006] systemd[1]: Listening on Journal Sockets.
[   14.571096] systemd[1]: Listening on DDI File System Mounter Socket.
[   14.600507] systemd[1]: Listening on Console Output Muting Service Socket.
[   14.601500] systemd[1]: Listening on Namespace Resource Manager Socket.
[   14.601935] systemd[1]: Userspace Out-Of-Memory (OOM) Killer Socket skipped, unmet condition check ConditionPathExists=/proc/pressure/memory
[   14.621373] systemd[1]: Listening on Disk Repartitioning Service Socket.
[   14.622525] systemd[1]: Listening on udev Control Socket.
[   14.623311] systemd[1]: Listening on udev Kernel Socket.
[   14.624256] systemd[1]: Listening on udev Varlink Socket.
[   14.626028] systemd[1]: Huge Pages File System skipped, unmet condition check ConditionPathExists=/sys/kernel/mm/hugepages
[   14.627440] systemd[1]: POSIX Message Queue File System skipped, unmet condition check ConditionPathExists=/proc/sys/fs/mqueue
[   14.704727] systemd[1]: Mounting Kernel Debug File System...
[   14.705775] systemd[1]: Kernel Trace File System skipped, unmet condition check ConditionPathExists=/sys/kernel/tracing
[   14.707110] systemd[1]: Create List of Static Device Nodes skipped, unmet condition check ConditionFileNotEmpty=/lib/modules/6.15.2/modules.devname
[   14.707729] systemd[1]: Load Kernel Module configfs skipped, unmet condition check ConditionKernelModuleLoaded=!configfs
[   14.712746] systemd[1]: Mounting Kernel Configuration File System...
[   14.713076] systemd[1]: Load Kernel Module drm skipped, unmet condition check ConditionKernelModuleLoaded=!drm
[   14.720663] systemd[1]: Starting Load Kernel Module efi_pstore...
[   14.721043] systemd[1]: Load Kernel Module fuse skipped, unmet condition check ConditionKernelModuleLoaded=!fuse
[   14.730261] systemd[1]: Mounting FUSE Control File System...
[   14.754954] systemd[1]: Starting Load firmware that is located on dedicated partitions of qcom devices...
[   14.765014] systemd[1]: Starting nftables static rule set...
[   14.771466] systemd[1]: Starting Enable compressed swap in memory using zram...
[   14.788058] systemd[1]: Starting Setting the system time according to an offset file...
[   14.791498] systemd[1]: systemd-journald.service: unit configures an IP firewall, but the local system does not support BPF/cgroup firewalling.
[   14.791542] systemd[1]: systemd-journald.service: (This warning is only shown for the first unit using IP firewalling.)
[   14.804944] systemd[1]: Starting Journal Service...
[   14.810532] systemd[1]: Load Kernel Modules skipped, no trigger condition checks were met.
[   14.830156] systemd[1]: Starting Remount Root and Kernel File Systems...
[   14.844666] systemd[1]: Starting Apply Kernel Variables...
[   14.865209] systemd[1]: Starting Wait Until Kernel Time Synchronized...
[   14.875089] systemd[1]: Starting Create Static Device Nodes in /dev gracefully...
[   14.895749] systemd[1]: Starting Load udev Rules from Credentials...
[   14.905110] systemd[1]: Starting Coldplug All udev Devices...
[   15.055311] EXT4-fs (loop0p2): re-mounted 041edd21-8a39-4d84-b4a3-582f8ee0a793.
[   15.089201] EXT4-fs (mmcblk0p1): mounted filesystem 57f8f4bc-abf4-655f-bf67-946fc0f9f25b ro with ordered data mode. Quota mode: disabled.
[   15.120955] systemd-journald[734]: Collecting audit messages is disabled.
[   15.408842] EXT4-fs (mmcblk0p24): VFS: Can't find ext4 filesystem
[   15.409512] EXT4-fs (mmcblk0p24): VFS: Can't find ext4 filesystem
[   15.410141] EXT2-fs (mmcblk0p24): error: can't find an ext2 filesystem on dev mmcblk0p24.
[   15.410733] FAT-fs (mmcblk0p24): bogus number of reserved sectors
[   15.410748] FAT-fs (mmcblk0p24): Can't find a valid FAT filesystem
[   15.508738] EXT4-fs (mmcblk0p29): mounted filesystem 57f8f4bc-abf4-655f-bf67-946fc0f9f25b ro with ordered data mode. Quota mode: disabled.
[   15.943376] systemd[1]: Started Journal Service.
[   16.685209] systemd-journald[734]: Received client request to flush runtime journal.
[   18.224438] random: crng init done
[   31.204578] l28: disabling
[  336.381070] systemd-journald[734]: Failed to set ACL on /var/log/journal/75736b105cac4d4db8a39f9f76a8facd/user-10000.journal, ignoring: Not supported
```

</details>