### PR TITLE
ARM: dts: qcom: msm8226-motorola-titan: Enable WiFi and touchscreen

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8226-motorola-titan.dts
+++ b/arch/arm/boot/dts/qcom/msm8226-motorola-titan.dts
@@ -84,6 +84,19 @@
 		regulator-boot-on;
 	};
 
+	vdd_touch_vreg: regulator-vdd-touch {
+		compatible = "regulator-fixed";
+		regulator-name = "vdd_touch";
+
+		gpio = <&tlmm 73 GPIO_ACTIVE_HIGH>;
+		startup-delay-us = <300>;
+		enable-active-high;
+		regulator-pull-down;
+
+		pinctrl-0 = <&tp_avdd_en_default_state>;
+		pinctrl-names = "default";
+	};
+
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -142,6 +155,39 @@
 			regulator-active-discharge = <1>;
 			regulator-boot-on;
 			enable-gpios = <&tlmm 13 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&blsp1_i2c5 {
+	status = "okay";
+
+	touchscreen@20 {
+		compatible = "syna,rmi4-i2c";
+		reg = <0x20>;
+
+		interrupts-extended = <&tlmm 17 IRQ_TYPE_EDGE_FALLING>;
+		reset-gpios = <&tlmm 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+
+		vdd-supply = <&vdd_touch_vreg>;
+		vio-supply = <&pm8226_lvs1>;
+
+		pinctrl-0 = <&touch_pin>;
+		pinctrl-names = "default";
+
+		syna,startup-delay-ms = <100>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		rmi4-f01@1 {
+			reg = <0x1>;
+			syna,nosleep-mode = <1>;
+		};
+
+		rmi4-f11@11 {
+			reg = <0x11>;
+			syna,sensor-type = <1>;
 		};
 	};
 };
@@ -388,6 +434,14 @@
 		output-high;
 	};
 
+	touch_pin: touch-state {
+		pins = "gpio17";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
+	};
+
 	sdhc2_cd_default: sdhc2-cd-default-state {
 		pins = "gpio38";
 		function = "gpio";
@@ -400,5 +454,13 @@
 		function = "wlan";
 		drive-strength = <2>;
 		bias-pull-up;
+	};
+
+	tp_avdd_en_default_state: touch-avdd-en-pin-default-state {
+		pins = "gpio73";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-pull-up;
+		output-high;
 	};
 };

--- a/arch/arm/boot/dts/qcom/msm8226-motorola-titan.dts
+++ b/arch/arm/boot/dts/qcom/msm8226-motorola-titan.dts
@@ -209,6 +209,7 @@
 		pm8226_l8: l8 {
 			regulator-min-microvolt = <1800000>;
 			regulator-max-microvolt = <1800000>;
+			regulator-always-on;
 		};
 
 		pm8226_l9: l9 {
@@ -354,6 +355,30 @@
 	v3p3-supply = <&pm8226_l20>;
 };
 
+&pronto {
+	vddmx-supply = <&pm8226_l3>;
+	vddpx-supply = <&pm8226_l6>;
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&wcnss_pin_a>;
+
+	status = "okay";
+
+	iris {
+		compatible = "qcom,wcn3620";
+		vddxo-supply = <&pm8226_l10>;
+		vddrfa-supply = <&pm8226_l24>;
+		vddpa-supply = <&pm8226_l16>;
+		vdddig-supply = <&pm8226_l24>;
+	};
+
+	smd-edge {
+		wcnss {
+			status = "okay";
+		};
+	};
+};
+
 &tlmm {
 	reg_lcd_default: reg-lcd-default-state {
 		pins = "gpio12", "gpio13";
@@ -366,6 +391,13 @@
 	sdhc2_cd_default: sdhc2-cd-default-state {
 		pins = "gpio38";
 		function = "gpio";
+		drive-strength = <2>;
+		bias-pull-up;
+	};
+
+	wcnss_pin_a: wcnss-pin-active-state {
+		pins =  "gpio40", "gpio41", "gpio42", "gpio43", "gpio44";
+		function = "wlan";
 		drive-strength = <2>;
 		bias-pull-up;
 	};


### PR DESCRIPTION
## WiFi

regulator-always-on for l3 and l8 prevents bootloops and instability.

Note: the following errors appear in `dmesg`, particularly when trying to use Bluetooth and WiFi at the same time. So far as I can tell, this is likely an issue with the driver, not the device tree.

```
wcn36xx: ERROR hal_enter_bmps response failed err=1
wcn36xx: ERROR Can not enter BMPS!
wcn36xx: ERROR SMD_EVENT (312) not supported
```

In particular, `SMD_EVENT (312)` is `WCN36XX_HAL_P2P_NOA_ATTR_IND` from `wcn36xx/hal.h` which is not explicitly handled by `wcn36xx_smd_rsp_process()` in `wcn36xx/smd.c`.

I have no idea how to fix that, and WiFi works great if I don't touch Bluetooth, so figured I should just send this.
(Bluetooth also works, but with a lot more dropouts. I haven't tried Bluetooth with WiFi disabled, but I was able to detect events from a paired PS4 DualShock controller before it dropped out.)

Thanks @erikas9987 for the hint about the regulators!

## Touchscreen

Enable the Synaptics RMI4 I2C touchscreen for motorola-titan.